### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/update-citation-cff.yaml
+++ b/.github/workflows/update-citation-cff.yaml
@@ -16,6 +16,9 @@ on:
 
 name: Update CITATION.cff
 
+permissions:
+  contents: write
+
 jobs:
   update-citation-cff:
     runs-on: macos-latest


### PR DESCRIPTION
Potential fix for [https://github.com/spectra-to-knowledge/SpectraToQueries/security/code-scanning/2](https://github.com/spectra-to-knowledge/SpectraToQueries/security/code-scanning/2)

To fix the problem, add a `permissions` block to the workflow to explicitly set the minimal required permissions for the `GITHUB_TOKEN`. Since the workflow commits and pushes changes to the repository, it needs `contents: write` permission. The `permissions` block should be added at the top level of the workflow file (before `jobs:`) so it applies to all jobs, unless a job-level override is needed. No additional imports or definitions are required; this is a YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
